### PR TITLE
Fix log4j yml pattern for ExternalAppender

### DIFF
--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -10,7 +10,7 @@ Configuration:
       -
         name: ExternalAppender
         PatternLayout:
-          Pattern: "%highlight{%date{yyMMdd H:mm:ss:SSS} [%level] (%logger{36}): %msg%n}"
+          Pattern: "%date{yyMMdd H:mm:ss:SSS} [%level] (%logger{36}): %msg%n"
 
   Loggers:
     logger:

--- a/src/main/resources/log4j2TeeToFile.yml
+++ b/src/main/resources/log4j2TeeToFile.yml
@@ -14,7 +14,7 @@ Configuration:
       -
         name: ExternalAppender
         PatternLayout:
-          Pattern: "%highlight{%date{yyMMdd H:mm:ss:SSS} [%level] (%logger{36}): %msg%n}"
+          Pattern: "%date{yyMMdd H:mm:ss:SSS} [%level] (%logger{36}): %msg%n"
     File:
       -
         name: IHMCFileAppender


### PR DESCRIPTION
The %highlight was causing problems because I think it expects extra params. I dont think it was important to have it for the ExternalAppender?

Fixes this issue:
```
2025-02-04T20:25:01.710140567Z main WARN Syntax error, missing '=': Expected "{KEY1=VALUE, KEY2=VALUE, ...}
```